### PR TITLE
utility function for rescaling a frame

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -320,6 +320,53 @@ exports.resample = function( frame, sourceRate, targetRate ) {
     return targetFrame;
 };
 
+/**
+ * @summary Rescales the frame.
+ *
+ * @description
+ * Assuming both source and target Bit depth are multiples of eight, this function rescales the
+ * frame. E.g. it can be used to make a 16 Bit audio frame of an 8 Bit audio frame.
+ *
+ * @param {Buffer} frame - Original frame
+ * @param {Number} sourceDepth - Original Bit depth
+ * @param {Boolean} sourceUnsigned - whether the source values are unsigned
+ * @param {Boolean} sourceBE - whether the source values are big endian
+ */
+exports.rescaleToUInt16LE = function (frame, sourceDepth, sourceUnsigned, sourceBE)
+{
+    if (sourceDepth === 16 && !sourceUnsigned && !sourceBE)
+    { return frame; }
+
+    if (sourceDepth !== 8 && sourceDepth !== 16 && sourceDepth !== 32)
+    { throw new Error('unsupported source depth ' + sourceDepth); }
+
+    var targetFrame = new Buffer(frame.length * 16 / sourceDepth);
+
+    var funcNameSuffix = sourceUnsigned ? 'UInt' : 'Int';
+    var readFunc =
+        frame[
+            'read' +
+            (sourceUnsigned ? 'U' : '') +
+            'Int' +
+            sourceDepth +
+            (sourceDepth !== 8 ? (sourceBE ? 'BE' : 'LE') : '')
+        ].bind(frame);
+
+    var srcSize = Math.pow(2, sourceDepth) - 1;
+    var srcOffset = sourceUnsigned ? 0 : (srcSize + 1) / -2;
+
+    var tgtSize = sourceUnsigned ? 32767 : 65535;
+    var tgtOffset = sourceUnsigned ? 0 : (tgtSize + 1) / -2;
+
+    var factor = tgtSize / srcSize;
+
+    var siStep = sourceDepth / 8;
+    for (var si = 0, ti = 0; si < frame.length; si += siStep, ti += 2)
+    { targetFrame.writeInt16LE(Math.round(tgtOffset + (readFunc(si) - srcOffset) * factor), ti); }
+
+    return targetFrame;
+};
+
 // Gather all versions and fix the values at the same time.
 var allVersions = [];
 for( var i in exports.celtVersions ) {


### PR DESCRIPTION
The MumbleInputStream requires frames to be of 16 Bit deep signed values. With this function 8 Bit deep unsigned or signed value frames can be upscaled to 16 Bit signed. It should also work with 16 Bit unsigned to 16 Bit signed and downscaling from 32 Bit, but that's not tested (and probably unneccessary as well).